### PR TITLE
chore(dev): add contributor guide, jest config, and static server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root SPA: `index.html` is the single-page app entry.
+- JS modules live at the repo root (e.g., `sum.js`).
+- Tests colocate using `*.test.js` (e.g., `sum.test.js`).
+- Dependencies are in `node_modules/` (already committed). Avoid editing by hand.
+
+## Build, Test, and Development Commands
+- Install: `npm install` — installs dev dependencies (e.g., Jest).
+- Test: `npm test` — runs the full Jest test suite once.
+- Watch tests: `npx jest --watch` — reruns tests on file changes.
+- Run locally: open `index.html` in a browser or serve statically (e.g., `python3 -m http.server 8080` then visit `http://localhost:8080`).
+
+## Coding Style & Naming Conventions
+- Language: JavaScript (`commonjs` modules via `require`/`module.exports`).
+- Indentation: 2 spaces; include semicolons; prefer single quotes; trailing commas optional.
+- Naming: files `kebab-case` or `lowercase` (e.g., `sum.js`); functions and variables `camelCase`; classes `PascalCase`.
+- Imports: use relative paths (e.g., `require('./sum')`).
+
+## Testing Guidelines
+- Framework: Jest.
+- File naming: `*.test.js` next to code under test.
+- Run: `npm test`; focused runs: `npx jest path/to/file.test.js -t "matches behavior"`.
+- Aim for small, behavior-focused tests; arrange–act–assert pattern; prefer pure functions.
+
+## Commit & Pull Request Guidelines
+- Commits: use Conventional Commits when possible (`feat:`, `fix:`, `chore:`, `docs:`). Keep messages imperative and scoped (e.g., `feat: add cube move validator`).
+- PRs: include a clear description, linked issues (e.g., `Closes #123`), test updates, and screenshots/GIFs for UI changes to `index.html`.
+- Keep PRs small and focused; note any breaking changes.
+
+## Security & Configuration Tips
+- Do not commit secrets or tokens. This repo is static; prefer client-safe configs only.
+- Large/generated assets: avoid adding unless necessary. `node_modules/` is currently tracked; do not edit it manually.
+- Browser compatibility: test in at least one Chromium-based browser; note any API assumptions in PRs.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.js'],
+  transform: {},
+};
+

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "An interactive Rubik's cube simulator as a SPA",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jody/CubeAI.git"
@@ -22,6 +19,9 @@
     "jest": "^30.1.1"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest --no-watchman",
+    "test:watch": "jest --watch --no-watchman",
+    "serve": "node scripts/serve.js",
+    "start": "node scripts/serve.js"
   }
 }

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = Number(process.env.PORT) || 8080;
+const root = process.cwd();
+
+const types = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.wasm': 'application/wasm'
+};
+
+function safePath(urlPath) {
+  const decoded = decodeURI(urlPath.split('?')[0]);
+  const clean = path.normalize(decoded).replace(/^\/+/, '');
+  const full = path.join(root, clean || 'index.html');
+  if (!full.startsWith(root)) return null; // path traversal guard
+  return full;
+}
+
+const server = http.createServer((req, res) => {
+  const filePath = safePath(req.url);
+  if (!filePath) {
+    res.writeHead(400).end('Bad Request');
+    return;
+  }
+
+  fs.stat(filePath, (err, stat) => {
+    if (!err && stat.isDirectory()) {
+      // Serve index.html for directories
+      return serveFile(path.join(filePath, 'index.html'), res, true);
+    }
+    if (!err && stat.isFile()) {
+      return serveFile(filePath, res);
+    }
+    // SPA fallback to index.html on 404 for HTML requests
+    const acceptsHTML = (req.headers['accept'] || '').includes('text/html');
+    if (acceptsHTML || !path.extname(filePath)) {
+      return serveFile(path.join(root, 'index.html'), res, true);
+    }
+    res.writeHead(404).end('Not Found');
+  });
+});
+
+function serveFile(fp, res, isFallback = false) {
+  fs.readFile(fp, (err, data) => {
+    if (err) {
+      if (isFallback) return res.writeHead(200, {'Content-Type': 'text/html; charset=utf-8'}).end('<!doctype html><title>SPA</title>');
+      return res.writeHead(404).end('Not Found');
+    }
+    const ext = path.extname(fp).toLowerCase();
+    const type = types[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type }).end(data);
+  });
+}
+
+server.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Static server running at http://localhost:${port}`);
+});
+


### PR DESCRIPTION
Adds AGENTS.md (contributor guide), jest.config.js (minimal Jest setup), and scripts/serve.js (static server).  Updates npm scripts to disable Watchman and add serve/start. 

How to test:
- npm install
- npm test
- npm run serve (open http://localhost:8080)